### PR TITLE
feat: make services scrollable for mobile screens

### DIFF
--- a/components/Page/Services.vue
+++ b/components/Page/Services.vue
@@ -5,7 +5,10 @@
     </PageHeader>
     <PageBody >
       <div class="mt-10">
-      <dl class="flex justify-center " >
+      <dl
+        class="overflow-x-auto flex"
+        style="width: 95vw"
+      >
         <CardService  
         :image="$t('pages.services.service-1.image')" 
         :title="$t('pages.services.service-1.title')" 


### PR DESCRIPTION
When the screen is smaller than the total width of services, they are wrapped in a scrollable fashion.