### PR TITLE
ADD: listings can stay without an application form

### DIFF
--- a/components/PostArticle.vue
+++ b/components/PostArticle.vue
@@ -37,7 +37,7 @@
       <markdown :markdown="post" />
       <!-- HTML !-->
       <a v-if="post.applyLink" :href="post.applyLink" class="button-42" role="button">Apply Here</a>
-      <jot-form v-else-if="type === 'career'" jotform="https://form.jotform.com/221312528166955" height="220px" />
+      <a v-else-if="type === 'career'">Applications are closed at the moment.</a><br>
       <div v-if="type !== 'hidden'" class="article__footer">
         <back-icon />
         <nuxt-link v-if="type === 'post'" to="/blog/" class="article__back">
@@ -69,12 +69,10 @@
 
 <script>
 import BackIcon from 'icons/KeyboardBackspace'
-import JotForm from './JotForm.vue'
 
 export default {
   components: {
-    BackIcon,
-    JotForm
+    BackIcon
   },
   props: {
     post: {

--- a/contents/career/embedded-software-engineer.md
+++ b/contents/career/embedded-software-engineer.md
@@ -3,7 +3,7 @@ title: "Embedded Software Engineer"
 description: "As a Embedded Software engineer, you will be bringing together hardware and software for our state of the art edge AI systems deployed in four continents. This role involves on-site attendance. (ODTU Teknokent, Ankara)"
 date: 2024-03-06 15:10:00 -0000
 background: '/img/posts/05.jpg'
-applyLink: 'https://forms.gle/9BUkKZjWQ7TN5376A'
+# applyLink: 'https://forms.gle/9BUkKZjWQ7TN5376A'
 ---
 
 ## A little about us


### PR DESCRIPTION
1. https://form.jotform.com/221312528166955 is removed

2. When the `applyLink` attribute of a job listing markdown file is commented out or deleted, the application button is replaced with the text: "Applications are closed at the moment."